### PR TITLE
[Feature] Listar vacantes por reclutador

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "ts-loader": "^9.5.2",
         "ts-node": "^10.9.2",
         "tsconfig-paths": "^4.2.0",
-        "typescript": "^5.7.3",
+        "typescript": "^5.8.3",
         "typescript-eslint": "^8.20.0"
       }
     },
@@ -13573,7 +13573,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "ts-loader": "^9.5.2",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3",
+    "typescript": "^5.8.3",
     "typescript-eslint": "^8.20.0"
   },
   "jest": {

--- a/src/applications/application.service.ts
+++ b/src/applications/application.service.ts
@@ -31,7 +31,7 @@ export class ApplicationService {
     const doc = await this.collection.add({
       ...dto,
       status: dto.status ?? ApplicationStatus.RECEIVED,
-      cvPath: dto.cvUrl,
+      cvUrl: dto.cvUrl,
       createdAt: FieldValue.serverTimestamp(),
     });
 
@@ -58,7 +58,7 @@ export class ApplicationService {
   async findAll(vacancyId: string, status?: ApplicationStatus, page = 1, limit = 10) {
     let query = this.collection
       .where('vacancyId', '==', vacancyId)
-    //  .orderBy('createdAt', 'desc');
+      .orderBy('createdAt', 'desc');
 
     if (status) {
       query = query.where('status', '==', status);

--- a/src/vacancies/vacancies.controller.ts
+++ b/src/vacancies/vacancies.controller.ts
@@ -126,4 +126,18 @@ export class VacanciesController {
         const isAdmin = req.user.role === 'admin';
         return this.vacanciesService.delete(id, userId, isAdmin);
     }
+
+    //Obtener vacantes del reclutador (pasando el id del reclutador)
+@Get('/reclutador/:userId')
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Roles('admin', 'user')
+@ApiOperation({ summary: 'Obtener todas las vacantes de un reclutador por UID' })
+@ApiParam({ name: 'userId', description: 'UID del reclutador' })
+@ApiResponse({ status: 200, description: 'Vacantes del reclutador listadas' })
+@ApiResponse({ status: 404, description: 'No se encontraron vacantes para el reclutador' })
+async findAllByRecruiter(@Param('userId') userId: string): Promise<any> {
+    return await this.vacanciesService.findAllVacanciesByRecruiter(userId);
 }
+
+}
+

--- a/src/vacancies/vacancies.service.ts
+++ b/src/vacancies/vacancies.service.ts
@@ -137,4 +137,6 @@ export class VacanciesService {
         await docRef.delete();
         return { id, message: 'Vacante eliminada correctamente' };
     }
+
+    
 }


### PR DESCRIPTION
Se implementó una nueva funcionalidad en el controlador de vacantes para obtener todas las vacantes asociadas a un reclutador específico mediante su UID. Esta funcionalidad permite filtrar y mostrar únicamente las vacantes creadas por el usuario reclutador, mejorando la organización y visualización de los datos.